### PR TITLE
whitelist based argument forwarding

### DIFF
--- a/examples/flake-parts/derivation/flake.nix
+++ b/examples/flake-parts/derivation/flake.nix
@@ -19,7 +19,7 @@
 
       perSystem = {config, pkgs, system, ...}: {
         checks = config.packages;
-        drvs.hello = {
+        drvs.test = {
 
           # select mkDerivation as a backend for this package
           imports = [drv-parts.modules.derivation];

--- a/modules/derivation-common/interface.nix
+++ b/modules/derivation-common/interface.nix
@@ -14,8 +14,44 @@
     type = t.nullOr t.str;
     default = null;
   };
-in {
-  options = {
+
+  # options forwarded to the final derivation function call
+  forwardedOptions = {
+    # basic arguments
+    args = optListOfStr;
+    outputs = lib.mkOption {
+      type = t.listOf t.str;
+      default = ["out"];
+    };
+    __structuredAttrs = lib.mkOption {
+      type = t.nullOr t.bool;
+      default = null;
+    };
+
+    # advanced attributes
+    allowedReferences = optListOfStr;
+    allowedRequisites = optListOfStr;
+    disallowedReferences = optListOfStr;
+    disallowedRequisites = optListOfStr;
+    exportReferenceGraph = lib.mkOption {
+      # TODO: make type stricter
+      type = t.nullOr (t.listOf (t.either t.str t.package));
+      default = null;
+    };
+    impureEnvVars = optListOfStr;
+    outputHash = optNullOrStr;
+    outputHashAlgo = optNullOrStr;
+    outputHashMode = optNullOrStr;
+    passAsFile = optListOfStr;
+    preferLocalBuild = optListOfStr;
+    allowSubstitutes = optNullOrBool;
+  };
+
+  # drv-parts specific options, not forwardedto the final deirvation call
+  drvPartsOptions = {
+    argsForward = l.mkOption {
+      type = t.attrsOf t.bool;
+    };
 
     # this will be the resulting derivation
     final.derivation-args = l.mkOption {
@@ -53,37 +89,13 @@ in {
       '';
     };
 
-    # basic arguments
-    args = optListOfStr;
     env = lib.mkOption {
       type = t.attrsOf (t.oneOf [t.bool t.int t.str t.path t.package]);
       default = {};
     };
-    outputs = lib.mkOption {
-      type = t.listOf t.str;
-      default = ["out"];
-    };
-    __structuredAttrs = lib.mkOption {
-      type = t.nullOr t.bool;
-      default = null;
-    };
 
-    # advanced attributes
-    allowedReferences = optListOfStr;
-    allowedRequisites = optListOfStr;
-    disallowedReferences = optListOfStr;
-    disallowedRequisites = optListOfStr;
-    exportReferenceGraph = lib.mkOption {
-      # TODO: make type stricter
-      type = t.nullOr (t.listOf (t.either t.str t.package));
-      default = null;
-    };
-    impureEnvVars = optListOfStr;
-    outputHash = optNullOrStr;
-    outputHashAlgo = optNullOrStr;
-    outputHashMode = optNullOrStr;
-    passAsFile = optListOfStr;
-    preferLocalBuild = optListOfStr;
-    allowSubstitutes = optNullOrBool;
   };
+in {
+  config.argsForward = l.mapAttrs (_: _: true) forwardedOptions;
+  options = forwardedOptions // drvPartsOptions;
 }

--- a/modules/derivation/interface.nix
+++ b/modules/derivation/interface.nix
@@ -1,10 +1,14 @@
 {config, lib, ...}: let
   l = lib // builtins;
   t = l.types;
-in {
+in rec {
   imports = [
     ../derivation-common
   ];
+
+  # signal that all options should be passed to the final derivation function
+  config.argsForward = l.mapAttrs (_: _: true) options;
+
   options = {
     # basic arguments
     builder = lib.mkOption {

--- a/modules/mkDerivation/interface.nix
+++ b/modules/mkDerivation/interface.nix
@@ -29,11 +29,17 @@
     type = t.nullOr (t.listOf (t.oneOf [t.str t.path t.package]));
     default = null;
   };
-in {
+
+in rec {
   imports = [
     ../derivation-common
   ];
+
+  # signal that all options should be passed to the final derivation function
+  config.argsForward = l.mapAttrs (_: _: true) options;
+
   options = {
+
     # from derivation
     builder = optPackage;
     __contentAddressed = optNullOrBool;

--- a/tests/htop/default.nix
+++ b/tests/htop/default.nix
@@ -29,7 +29,7 @@
 
   nixpkgs-htop = pkgs.htop;
 in
-  # assert my-htop.drvPath == nixpkgs-htop.drvPath;
+  assert my-htop.drvPath == nixpkgs-htop.drvPath;
   {
     inherit
       my-htop


### PR DESCRIPTION
Before, there was complexity in filtering out arguments that should not passed to the final derivation function.

This seems unnecessary. All our options are defined explicitly already, so we should have an explicit whitelist of forwarded options.

Maybe this can simplify approaches like https://github.com/DavHau/drv-parts/pull/5