### PR TITLE
Feature: Flags

### DIFF
--- a/examples/flake-parts/htop-imported-from-nixpkgs/flake.nix
+++ b/examples/flake-parts/htop-imported-from-nixpkgs/flake.nix
@@ -34,8 +34,10 @@
         # configuration/overriding can be done like this:
         drvs = {
           # these options have been generated automatically by `makeModule`
-          htop.systemdSupport = true;
-          htop.sensorsSupport = true;
+          htop.flags = {
+            systemdSupport = true;
+            sensorsSupport = true;
+          };
           htop.buildInputs = [
             # add build inputs here
           ];
@@ -49,10 +51,12 @@
           lm_sensors.deps.rrdtool = null;
 
           ncurses.deps.abiVersion = "6";
-          ncurses.mouseSupport = false;
-          ncurses.unicodeSupport = true;
-          ncurses.withCxx = true;
-          ncurses.enableStatic = false;
+          ncurses.flags = {
+            mouseSupport = false;
+            unicodeSupport = true;
+            withCxx = true;
+            enableStatic = false;
+          };
         };
 
         checks =

--- a/examples/flake-parts/htop/flake.nix
+++ b/examples/flake-parts/htop/flake.nix
@@ -31,7 +31,7 @@
           htop-mod = {
             imports = [./htop.nix];
             pname = lib.mkForce "htop-mod";
-            sensorsSupport = false;
+            flags.sensorsSupport = false;
             stdenv = pkgs.stdenv;
           };
         };

--- a/examples/flake-parts/htop/htop.nix
+++ b/examples/flake-parts/htop/htop.nix
@@ -5,12 +5,14 @@ in {
   # select mkDerivation as a backend for this package
   imports = [drv-backends.mkDerivation];
 
-  options = {
+  options.flags = {
     sensorsSupport = lib.mkOption {
+      description = "enable support for sensors";
       type = lib.types.bool;
       default = config.stdenv.isLinux;
     };
     systemdSupport = lib.mkOption {
+      description = "enable support for systemd";
       type = lib.types.bool;
       default = config.stdenv.isLinux;
     };
@@ -43,12 +45,12 @@ in {
 
     buildInputs = [ deps.ncurses ]
       ++ lib.optional config.stdenv.isDarwin deps.IOKit
-      ++ lib.optional config.sensorsSupport deps.lm_sensors
-      ++ lib.optional config.systemdSupport deps.systemd
+      ++ lib.optional config.flags.sensorsSupport deps.lm_sensors
+      ++ lib.optional config.flags.systemdSupport deps.systemd
     ;
 
     configureFlags = [ "--enable-unicode" "--sysconfdir=/etc" ]
-      ++ lib.optional config.sensorsSupport "--with-sensors"
+      ++ lib.optional config.flags.sensorsSupport "--with-sensors"
     ;
 
     postFixup =
@@ -56,8 +58,8 @@ in {
         optionalPatch = pred: so: lib.optionalString pred "patchelf --add-needed ${so} $out/bin/htop";
       in
       ''
-        ${optionalPatch config.sensorsSupport "${deps.lm_sensors}/lib/libsensors.so"}
-        ${optionalPatch config.systemdSupport "${deps.systemd}/lib/libsystemd.so"}
+        ${optionalPatch config.flags.sensorsSupport "${deps.lm_sensors}/lib/libsensors.so"}
+        ${optionalPatch config.flags.systemdSupport "${deps.systemd}/lib/libsystemd.so"}
       '';
 
     meta = with lib; {

--- a/examples/flake-parts/htop/htop.nix
+++ b/examples/flake-parts/htop/htop.nix
@@ -5,23 +5,19 @@ in {
   # select mkDerivation as a backend for this package
   imports = [drv-backends.mkDerivation];
 
-  options.flags = {
-    sensorsSupport = lib.mkOption {
-      description = "enable support for sensors";
-      type = lib.types.bool;
-      default = config.stdenv.isLinux;
-    };
-    systemdSupport = lib.mkOption {
-      description = "enable support for systemd";
-      type = lib.types.bool;
-      default = config.stdenv.isLinux;
-    };
-  };
-
   config = {
     # set options
     pname = "htop";
     version = "3.2.1";
+
+    flagsOffered = {
+      sensorsSupport = "enable support for sensors";
+      systemdSupport = "enable support for sensors";
+    };
+
+    # set defaults for flags
+    flags.sensorsSupport = lib.mkDefault config.stdenv.isLinux;
+    flags.systemdSupport = lib.mkDefault config.stdenv.isLinux;
 
     deps = {pkgs, ...}: {
       inherit (pkgs)

--- a/examples/no-flake/mkDerivation/default.nix
+++ b/examples/no-flake/mkDerivation/default.nix
@@ -3,16 +3,23 @@
   drv-parts ? import ../../../default.nix {inherit (pkgs) lib;},
   ...
 }: let
-  hello = {
+  hello = {config, ...}: {
     # select mkDerivation as a backend for this package
     imports = [drv-parts.modules.mkDerivation];
 
     # set options
-    pname = "hello";
+    pname =
+      if config.flags.enableFoo
+      then "hello-with-foo"
+      else "hello";
     version = pkgs.hello.version;
     src = pkgs.hello.src;
     doCheck = true;
     stdenv = pkgs.stdenv;
+
+    flagsOffered = {
+      enableFoo = "build with foo";
+    };
   };
 in
   drv-parts.lib.derivationFromModules hello

--- a/lib/makeModule.nix
+++ b/lib/makeModule.nix
@@ -62,14 +62,14 @@ in {config, options, ...}: {
 
   imports = [../modules/mkDerivation/interface.nix];
 
-  options = flagOptions;
+  options.flags = flagOptions;
 
   config = let
 
     # raises errors if a dependency is missing from `config.deps`
     ensuredDeps = ensureDepsPopulated config.deps;
 
-    pickFlag = flagName: _: config.${flagName};
+    pickFlag = flagName: _: config.flags.${flagName};
     pickDep = depName: _: ensuredDeps.${depName};
     flagArgs' = l.mapAttrs pickFlag flagArgs;
     depArgs' = l.mapAttrs pickDep depArgs;

--- a/modules/derivation-common/interface.nix
+++ b/modules/derivation-common/interface.nix
@@ -14,6 +14,11 @@
     type = t.nullOr t.str;
     default = null;
   };
+  mkFlag = description: l.mkOption {
+    inherit description;
+    type = t.bool;
+    default = false;
+  };
 
   # options forwarded to the final derivation function call
   forwardedOptions = {
@@ -48,6 +53,46 @@
   drvPartsOptions = {
     argsForward = l.mkOption {
       type = t.attrsOf t.bool;
+    };
+
+    /*
+      Helper option to define `flags`.
+      This makes the syntax for defining flags simpler and at the same time
+        prevents users to make mistakes like, for example, defining flags with
+        other types than bool.
+
+      This allows flags to be defined like this:
+      {
+        config.flagsOffered = {
+          enableFoo = "builds with foo support";
+          ...
+        };
+      }
+
+      ... instead of this:
+      {
+        options.flags = {
+          enableFoo = l.mkOption {
+            type = t.bool;
+            description = "builds with foo support";
+            default = false;
+          };
+          ...
+        }
+      }
+
+    */
+    flagsOffered = l.mkOption {
+      type = t.attrsOf t.str;
+      default = {};
+    };
+
+    # The flag options generated from `flagsOffered`
+    flags = l.mkOption {
+      type = t.submodule {
+        options = l.mapAttrs (_: mkFlag) config.flagsOffered;
+      };
+      default = {};
     };
 
     final.derivation-args = l.mkOption {


### PR DESCRIPTION
This introduces options `flagsOffered` and `flags` to provide and set flags.
This provides a distinct place for boolean configuration options like for example `enableSystemd` or `fooSupport`.
To have these `flags` separated out, can only be beneficial, as it offers better potential to extend drv-parts with features specific to `flags`.

This allows us to add logic similar to `Cargo Features`, where packages can enable flags of other packages they depend on. 