### PR TITLE
change mechanism for `deps`; add `depsRequired`; add `depsFrom`.

### DIFF
--- a/examples/flake-parts/htop-imported-from-nixpkgs/drvs.nix
+++ b/examples/flake-parts/htop-imported-from-nixpkgs/drvs.nix
@@ -5,42 +5,14 @@
   packages
 }:
 let
-  depsFromNixpkgs = {
-    inherit (pkgs)
-      # some of these packages could also be ported to drv-parts via
-      # makeModule, but for demonstration purposes, we want to keep the
-      # list short, and inherit them from nixpkgs instead.
-      autoreconfHook
-      bash
-      binutils
-      fetchurl
-      fetchFromGitHub
-      stdenv
-      IOKit
-      forFHSEnv
-      util-linux
-      help2man
-      m4
-      perl
-      flex
-      which
-      pkg-config
-      gpm
-      libintl
-      procps
-      xz
-      systemd
-      ;
-    buildPackages.perl = pkgs.perl;
-    buildPackages.stdenv.cc = pkgs.buildPackages.stdenv.cc;
-    # this can be null because we set `htop.systemdSupport = false`
-    # systemd = null;
-  };
-
-  allDeps = packages // depsFromNixpkgs;
 
   commonModule = {
-    deps = allDeps;
+    /*
+      To keep this simple, only a few packages have been converted to modules,
+        while the rest is still taken from nixpkgs.
+      `// pkgs` can be removed once all packages are modules.
+    */
+    depsFrom = packages // pkgs;
     stdenv = pkgs.stdenv;
   };
 

--- a/examples/flake-parts/htop/flake.nix
+++ b/examples/flake-parts/htop/flake.nix
@@ -23,9 +23,11 @@
         drvs = {
 
           # htop defined via submodule
-          htop.imports = [./htop.nix];
-
-          htop.stdenv = pkgs.stdenv;
+          htop = {
+            imports = [./htop.nix];
+            stdenv = pkgs.stdenv;
+            depsFrom = pkgs;
+          };
 
           # overriding htop
           htop-mod = {
@@ -33,6 +35,7 @@
             pname = lib.mkForce "htop-mod";
             flags.sensorsSupport = false;
             stdenv = pkgs.stdenv;
+            depsFrom = pkgs;
           };
         };
 

--- a/examples/flake-parts/htop/htop.nix
+++ b/examples/flake-parts/htop/htop.nix
@@ -19,7 +19,7 @@ in {
     flags.sensorsSupport = lib.mkDefault config.stdenv.isLinux;
     flags.systemdSupport = lib.mkDefault config.stdenv.isLinux;
 
-    # This must be complete, otherwise `deps` would have attributes missing.
+    # This must be complete, otherwise options would be missing from `deps`.
     depsRequired = {
       autoreconfHook = true;
       fetchFromGitHub = true;

--- a/examples/flake-parts/htop/htop.nix
+++ b/examples/flake-parts/htop/htop.nix
@@ -19,15 +19,14 @@ in {
     flags.sensorsSupport = lib.mkDefault config.stdenv.isLinux;
     flags.systemdSupport = lib.mkDefault config.stdenv.isLinux;
 
-    deps = {pkgs, ...}: {
-      inherit (pkgs)
-        autoreconfHook
-        fetchFromGitHub
-        IOKit
-        lm_sensors
-        ncurses
-        systemd
-        ;
+    # This must be complete, otherwise `deps` would have attributes missing.
+    depsRequired = {
+      autoreconfHook = true;
+      fetchFromGitHub = true;
+      IOKit = true;
+      lm_sensors = true;
+      ncurses = true;
+      systemd = true;
     };
 
     src = deps.fetchFromGitHub {

--- a/examples/no-flake/hello-from-nixpkgs/default.nix
+++ b/examples/no-flake/hello-from-nixpkgs/default.nix
@@ -11,16 +11,7 @@
   # define another module to set `deps`
   helloDeps = {
 
-    deps = {
-      inherit hello; # the default.nix of hello wants hello as an input.
-      inherit (pkgs)
-        fetchurl
-        stdenv
-        callPackage
-        nixos
-        testers
-        ;
-    };
+    depsFrom = pkgs // {inherit hello;};
 
     stdenv = pkgs.stdenv;
   };

--- a/flake.nix
+++ b/flake.nix
@@ -31,7 +31,7 @@
       perSystem = {system, pkgs, ...}: {
         packages.tests-examples = pkgs.writeShellScriptBin "tests-examples" ''
           set -eu -o pipefail
-          for example in $(find ./examples/flake-parts/ -type f); do
+          for example in $(find ./examples/flake-parts/ -type f -name 'flake.nix'); do
             echo "building example $example"
             nix flake check "$example" -L \
               --show-trace \

--- a/modules/derivation-common/interface.nix
+++ b/modules/derivation-common/interface.nix
@@ -1,7 +1,6 @@
-{config, lib, dependencySets, ...}: let
+{config, lib, ...}: let
   l = lib // builtins;
   t = l.types;
-  callDeps = func: func dependencySets;
   optNullOrBool = l.mkOption {
     type = t.nullOr t.bool;
     default = null;
@@ -18,6 +17,15 @@
     inherit description;
     type = t.bool;
     default = false;
+  };
+  # make option for a given dependency name
+  mkDepOpt = depName: _: l.mkOption {
+    description = ''
+      Specify a package for the dependency ${depName}.
+      By default `config.depsFrom.${depName}` is used.
+    '';
+    type = t.raw;
+    default = config.depsFrom.${depName};
   };
 
   # options forwarded to the final derivation function call
@@ -103,32 +111,32 @@
       type = t.package;
     };
 
-    /*
-      This allows defining drvs in an encapsulated manner, while maintaining
-        the capability to depend on external attributes
-    */
-    deps = l.mkOption {
-      description = ''
-        All dependencies of the package. This option should be set by the "outer world" and can be used to inherit attributes from `pkgs` or `inputs` etc.
-
-        By separating the task of retrieving things from the outside world, it is ensured that the dependencies are overridable.
-        Nothing will stop users from adding `pkgs` itself as a dependency, but this will make it very hard for the user of the package to override any dependencies, because they'd have to figure out a way to insert their changes into the Nixpkgs fixpoint. By adding specific attributes to `deps` instead, the user has a realistic chance of overriding those dependencies.
-
-        So deps should be specific, but not overly specific. For instance, the caller shouldn't have to know the version of a dependency in order to override it. The name should suffice. (e.g. `nix = nixVersions.nix_2_12` instead of `inherit (nixVersions) nix_2_12`.
-      '';
-      type =
-        t.coercedTo
-        (t.functionTo (t.lazyAttrsOf t.raw))
-        callDeps
-        (t.lazyAttrsOf t.raw);
+    depsRequired = l.mkOption {
+      type = t.attrsOf t.bool;
       default = {};
-      example = lib.literalExpression ''
-        {pkgs, inputs', ...}: {
-          inherit (pkgs) stdenv;
-          inherit (pkgs.haskellPackages) pandoc;
-          nix = inputs'.nix.packages.default;
+    };
+
+    /*
+      Attrset of required dependencies.
+      For example, when `config.depsRequired.bash = true`, then this creates:
+      {
+        options.deps = l.mkOption {
+          description = "spcify a package for the dependency bash"
+          type = t.raw;
+          default = config.fromDeps.bash;
         }
-      '';
+      }
+    */
+    deps =
+      l.mapAttrs
+      mkDepOpt
+      (l.filterAttrs (_: enabled: enabled) config.depsRequired);
+
+    # Unspecified `deps` are taken from `depsFrom`. It's a source for defaults.
+    depsFrom = l.mkOption {
+      description = "Package set to populate unspecified `deps`";
+      type = t.lazyAttrsOf t.raw;
+      default = {};
     };
 
     env = lib.mkOption {

--- a/modules/derivation-common/interface.nix
+++ b/modules/derivation-common/interface.nix
@@ -123,7 +123,7 @@
         options.deps = l.mkOption {
           description = "spcify a package for the dependency bash"
           type = t.raw;
-          default = config.fromDeps.bash;
+          default = config.depsFrom.bash;
         }
       }
     */

--- a/modules/drv-parts.nix
+++ b/modules/drv-parts.nix
@@ -13,7 +13,6 @@ in {
               modules = [./derivation-common];
               specialArgs = {
                 inherit (inputs.drv-parts) drv-backends;
-                inherit (config) dependencySets;
               };
             }
           );
@@ -39,13 +38,9 @@ in {
               # select mkDerivation as a backend for this package
               imports = [drv-parts.modules.mkDerivation];
 
-              # Define dependencies from the "outer world" only via `deps`.
-              # This allows for easy overriding later.
-              deps = {pkgs, ...} {
-                inherit (pkgs)
-                  fetchurl
-                  python
-                  ;
+              # Define dependencies from the "outer world" only via `depsFrom`.
+              # This allows for easy overriding via `config.deps` later.
+              depsFrom = {inherit (pkgs) fetchurl python};
               };
 
               # set options
@@ -63,23 +58,6 @@ in {
                 python -c "print('example')" > $out/example
               '''';
             };
-          '';
-        };
-
-        dependencySets = l.mkOption {
-          type = t.lazyAttrsOf t.raw;
-          default = {
-            inherit pkgs inputs';
-            inherit (self') packages;
-          };
-          description = ''
-            Define the package sets which can be used to pick dependencies from.
-            Basically this specifies the arguments passed to the function defined via drvs.<name>.deps.
-          '';
-          example = lib.literalExpression ''
-            {
-              inherit pkgs inputs';
-            }
           '';
         };
       };

--- a/tests/htop/default.nix
+++ b/tests/htop/default.nix
@@ -10,7 +10,6 @@
     drv = pkgs.lib.evalModules {
       specialArgs = {
         inherit (drv-parts) drv-backends;
-        dependencySets = {inherit pkgs;};
       };
       modules = modules;
     };
@@ -23,6 +22,7 @@
       stdenv = pkgs.stdenv;
       src = l.mkForce pkgs.htop.src;
       version =  l.mkForce pkgs.htop.version;
+      depsFrom = pkgs;
     }
   ];
 


### PR DESCRIPTION
@roberth It would be amazing if you could review this. I really want to get this right.

With this commit, the user is forced to explicitly specify all required dependency names via `depsRequired`. `options.deps` contains generated options for all names of `depsRequired`. These options are populated with defaults from `depsFrom`, The examples under `./examples` show how this is used.

The `coercedTo` type of `deps` had some weaknesses:
1. It was not possible to specify required dependencies explicitly, because it was not possible to create nested options like`options.deps.bash = mkOption ...`.
2. Because of (1.) I had to add a manual check in makeModule.nix to ensure that all required `deps` are populated by the user.

Having actual options for all required dependencies allows to reduce complexity and hand the `checking` off to the module system.

Also, when rendering the options for a package to a doc, all dependencies now appear as an option, which I think is great. It allows the user to see all inputs of a package without having to read the code.

This whole `deps` mechanism is generic enough to suit as a general `inputs`. It probably should be renamed to `inputs` in the future, but I don't want to clutter this PR too much.

EDIT:
`options.stdenv` can now probably be moved to `options.deps.stdenv`. It is basically just a dependency of the derivation and I see no need for special treatment.