### PR TITLE
feat: allow options for `deps`

### DIFF
--- a/examples/no-flake/derivation/default.nix
+++ b/examples/no-flake/derivation/default.nix
@@ -14,4 +14,4 @@
     system = builtins.currentSystem;
   };
 in
-  drv-parts.lib.derivationFromModules hello
+  drv-parts.lib.derivationFromModules {} hello

--- a/examples/no-flake/hello-from-nixpkgs/default.nix
+++ b/examples/no-flake/hello-from-nixpkgs/default.nix
@@ -25,7 +25,7 @@
     stdenv = pkgs.stdenv;
   };
 
-  hello = drv-parts.lib.derivationFromModules [
+  hello = drv-parts.lib.derivationFromModules {} [
     helloDefaultNix
     helloDeps
   ];

--- a/examples/no-flake/mkDerivation/default.nix
+++ b/examples/no-flake/mkDerivation/default.nix
@@ -22,4 +22,4 @@
     };
   };
 in
-  drv-parts.lib.derivationFromModules hello
+  drv-parts.lib.derivationFromModules {} hello

--- a/lib.nix
+++ b/lib.nix
@@ -4,9 +4,10 @@
 let
   l = lib // builtins;
 
-  derivationFromModules = modules: let
+  derivationFromModules = dependencySets: modules: let
     drv = lib.evalModules {
       modules = if l.isList modules then modules else [modules];
+      specialArgs = {inherit dependencySets;};
     };
   in
     drv.config.final.derivation;

--- a/modules/derivation-common/interface.nix
+++ b/modules/derivation-common/interface.nix
@@ -1,7 +1,6 @@
 {config, lib, dependencySets, ...}: let
   l = lib // builtins;
   t = l.types;
-  callDeps = func: func dependencySets;
   optNullOrBool = l.mkOption {
     type = t.nullOr t.bool;
     default = null;
@@ -116,12 +115,12 @@
 
         So deps should be specific, but not overly specific. For instance, the caller shouldn't have to know the version of a dependency in order to override it. The name should suffice. (e.g. `nix = nixVersions.nix_2_12` instead of `inherit (nixVersions) nix_2_12`.
       '';
-      type =
-        t.coercedTo
-        (t.functionTo (t.lazyAttrsOf t.raw))
-        callDeps
-        (t.lazyAttrsOf t.raw);
-      default = {};
+      type = t.submoduleWith {
+        # TODO: This could be made stricter by removing the freeformType
+        # Maybe add option `strictDeps = true/false` ? ;P
+        modules = [{freeformType = t.lazyAttrsOf t.raw;}];
+        specialArgs = dependencySets;
+      };
       example = lib.literalExpression ''
         {pkgs, inputs', ...}: {
           inherit (pkgs) stdenv;

--- a/modules/drv-parts.nix
+++ b/modules/drv-parts.nix
@@ -13,7 +13,7 @@ in {
               modules = [./derivation-common];
               specialArgs = {
                 inherit (inputs.drv-parts) drv-backends;
-                inherit (config) dependencySets;
+                inherit (config.drv-parts) dependencySets;
               };
             }
           );
@@ -66,7 +66,7 @@ in {
           '';
         };
 
-        dependencySets = l.mkOption {
+        drv-parts.dependencySets = l.mkOption {
           type = t.lazyAttrsOf t.raw;
           default = {
             inherit pkgs inputs';


### PR DESCRIPTION
This changes the type for `deps` so that nested options are allowed.

A drv module can now specify required dependencies. The module system will ensure that those options will be set. This also allows to render a manual for a packages interface including the required deps.

The `deps = {pkgs, ...}: {inherit (deps) ...;}` style remains intact.