### PR TITLE
add shellHook option

### DIFF
--- a/modules/mkDerivation/interface.nix
+++ b/modules/mkDerivation/interface.nix
@@ -123,6 +123,7 @@
     distPhase = optNullOrStr;
     preDist = optNullOrStr;
     postDist = optNullOrStr;
+    shellHook = optNullOrStr;
 
     # setup.sh flags
     dontUnpack = optNullOrBool;


### PR DESCRIPTION
I also found some references to `preShellHook` and `postShellHook` in nixpkgs, but only in python packages so I don't think they're relevant for `stdenv.mkDerivation`.