### PR TITLE
fix: use attrNames on contexts in multi-drv detection

### DIFF
--- a/modules/drv-parts/derivation-common/implementation.nix
+++ b/modules/drv-parts/derivation-common/implementation.nix
@@ -53,7 +53,7 @@
   outputPaths = l.mapAttrs (_: drv: "${drv}") outputDrvs;
 
   outputDrvsContexts =
-    l.mapAttrsToList (output: path: l.getContext path) outputPaths;
+    l.mapAttrsToList (output: path: l.attrNames (l.getContext path)) outputPaths;
 
   isSingleDrvPackage = (l.length (l.unique outputDrvsContexts)) == 1;
 


### PR DESCRIPTION
For a drv containing 2 outputs, `getContext` gives you something like this:
```nix
{
  "/nix/store/asdfasdf-hello.drv".outputs = [ "out" ];
}
```
```nix
{
  "/nix/store/asdfasdf-hello.drv".outputs = [ "dist" ];
}
```

`unique` will count these as 2 distinct values, meaning the `isSingleDrvPackage` check will always fail if the derivation has more than one output. My fix simply calls `attrNames` on the attrset returned by `getContext`, which should result in the desired behavior.