### PR TITLE
feat(package-func): expose outputName

### DIFF
--- a/modules/drv-parts/package-func/implementation.nix
+++ b/modules/drv-parts/package-func/implementation.nix
@@ -39,6 +39,7 @@
       inherit config extendModules;
       drvPath = throwIfMultiDrvOr outputDrvs.out.drvPath;
       outPath = throwIfMultiDrvOr outputDrvs.out.outPath;
+      outputName = throwIfMultiDrvOr outputDrvs.out.outputName;
       type = "derivation";
     };
 in {

--- a/modules/drv-parts/public/optsPackageCompat.nix
+++ b/modules/drv-parts/public/optsPackageCompat.nix
@@ -13,6 +13,9 @@ in {
   outPath = l.mkOption {
     type = t.path;
   };
+  outputName = l.mkOption {
+    type = t.str;
+  };
   type = l.mkOption {
     type = t.str;
     default = "derivation";


### PR DESCRIPTION
This seems useful, as `nix run .#installable` uses this attribute.